### PR TITLE
Change `grpc` to `grpc-js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "proto/"
   ],
   "scripts": {
-    "protoc:compile": "npx grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./proto/compiled --grpc_out=./proto/compiled --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` -I ./proto ./proto/*.proto",
-    "protoc:types": "npx grpc_tools_node_protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=./proto/compiled -I ./proto ./proto/*.proto",
+    "protoc:compile": "npx grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./proto/compiled --grpc_out=grpc_js:./proto/compiled --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` -I ./proto ./proto/*.proto",
+    "protoc:types": "npx grpc_tools_node_protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=grpc_js:./proto/compiled -I ./proto ./proto/*.proto",
     "clean": "rimraf build",
     "build": "npm run clean && tsc",
     "lint": "balena-lint src tests",
@@ -44,12 +44,11 @@
     "@types/dockerode": "^2.5.34",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.17.4",
-    "balena-config-karma": "^2.3.1",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "dockerode": "^3.3.0",
-    "grpc-tools": "^1.11.2",
-    "grpc_tools_node_protoc_ts": "^4.1.5",
+    "grpc_tools_node_protoc_ts": "^5.3.2",
+    "grpc-tools": "^1.11.3",
     "husky": "^4.3.8",
     "lint-staged": "^11.0.0",
     "mocha": "^8.4.0",
@@ -59,9 +58,9 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.7.3",
     "@types/google-protobuf": "^3.15.2",
-    "google-protobuf": "^3.17.3",
-    "grpc": "^1.24.10"
+    "google-protobuf": "^3.17.3"
   },
   "versionist": {
     "publishedAt": "2022-11-21T07:58:16.084Z"

--- a/proto/compiled/gogo_pb.js
+++ b/proto/compiled/gogo_pb.js
@@ -2,11 +2,14 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/compiled/logproto_grpc_pb.d.ts
+++ b/proto/compiled/logproto_grpc_pb.d.ts
@@ -4,172 +4,477 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import * as grpc from "grpc";
-import * as logproto_pb from "./logproto_pb";
-import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb";
-import * as gogo_pb from "./gogo_pb";
+import * as grpc from '@grpc/grpc-js';
+import * as logproto_pb from './logproto_pb';
+import * as google_protobuf_timestamp_pb from 'google-protobuf/google/protobuf/timestamp_pb';
+import * as gogo_pb from './gogo_pb';
 
-interface IPusherService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
-    push: IPusherService_IPush;
+interface IPusherService
+	extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
+	push: IPusherService_IPush;
 }
 
-interface IPusherService_IPush extends grpc.MethodDefinition<logproto_pb.PushRequest, logproto_pb.PushResponse> {
-    path: string; // "/logproto.Pusher/Push"
-    requestStream: boolean; // false
-    responseStream: boolean; // false
-    requestSerialize: grpc.serialize<logproto_pb.PushRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.PushRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.PushResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.PushResponse>;
+interface IPusherService_IPush
+	extends grpc.MethodDefinition<
+		logproto_pb.PushRequest,
+		logproto_pb.PushResponse
+	> {
+	path: '/logproto.Pusher/Push';
+	requestStream: false;
+	responseStream: false;
+	requestSerialize: grpc.serialize<logproto_pb.PushRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.PushRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.PushResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.PushResponse>;
 }
 
 export const PusherService: IPusherService;
 
-export interface IPusherServer {
-    push: grpc.handleUnaryCall<logproto_pb.PushRequest, logproto_pb.PushResponse>;
+export interface IPusherServer extends grpc.UntypedServiceImplementation {
+	push: grpc.handleUnaryCall<logproto_pb.PushRequest, logproto_pb.PushResponse>;
 }
 
 export interface IPusherClient {
-    push(request: logproto_pb.PushRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
-    push(request: logproto_pb.PushRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
-    push(request: logproto_pb.PushRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
+	push(
+		request: logproto_pb.PushRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	push(
+		request: logproto_pb.PushRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	push(
+		request: logproto_pb.PushRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
 }
 
 export class PusherClient extends grpc.Client implements IPusherClient {
-    constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
-    public push(request: logproto_pb.PushRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
-    public push(request: logproto_pb.PushRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
-    public push(request: logproto_pb.PushRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.PushResponse) => void): grpc.ClientUnaryCall;
+	constructor(
+		address: string,
+		credentials: grpc.ChannelCredentials,
+		options?: Partial<grpc.ClientOptions>,
+	);
+	public push(
+		request: logproto_pb.PushRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public push(
+		request: logproto_pb.PushRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public push(
+		request: logproto_pb.PushRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.PushResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
 }
 
-interface IQuerierService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
-    query: IQuerierService_IQuery;
-    label: IQuerierService_ILabel;
-    tail: IQuerierService_ITail;
-    series: IQuerierService_ISeries;
-    tailersCount: IQuerierService_ITailersCount;
+interface IQuerierService
+	extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
+	query: IQuerierService_IQuery;
+	label: IQuerierService_ILabel;
+	tail: IQuerierService_ITail;
+	series: IQuerierService_ISeries;
+	tailersCount: IQuerierService_ITailersCount;
 }
 
-interface IQuerierService_IQuery extends grpc.MethodDefinition<logproto_pb.QueryRequest, logproto_pb.QueryResponse> {
-    path: string; // "/logproto.Querier/Query"
-    requestStream: boolean; // false
-    responseStream: boolean; // true
-    requestSerialize: grpc.serialize<logproto_pb.QueryRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.QueryRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.QueryResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.QueryResponse>;
+interface IQuerierService_IQuery
+	extends grpc.MethodDefinition<
+		logproto_pb.QueryRequest,
+		logproto_pb.QueryResponse
+	> {
+	path: '/logproto.Querier/Query';
+	requestStream: false;
+	responseStream: true;
+	requestSerialize: grpc.serialize<logproto_pb.QueryRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.QueryRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.QueryResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.QueryResponse>;
 }
-interface IQuerierService_ILabel extends grpc.MethodDefinition<logproto_pb.LabelRequest, logproto_pb.LabelResponse> {
-    path: string; // "/logproto.Querier/Label"
-    requestStream: boolean; // false
-    responseStream: boolean; // false
-    requestSerialize: grpc.serialize<logproto_pb.LabelRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.LabelRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.LabelResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.LabelResponse>;
+interface IQuerierService_ILabel
+	extends grpc.MethodDefinition<
+		logproto_pb.LabelRequest,
+		logproto_pb.LabelResponse
+	> {
+	path: '/logproto.Querier/Label';
+	requestStream: false;
+	responseStream: false;
+	requestSerialize: grpc.serialize<logproto_pb.LabelRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.LabelRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.LabelResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.LabelResponse>;
 }
-interface IQuerierService_ITail extends grpc.MethodDefinition<logproto_pb.TailRequest, logproto_pb.TailResponse> {
-    path: string; // "/logproto.Querier/Tail"
-    requestStream: boolean; // false
-    responseStream: boolean; // true
-    requestSerialize: grpc.serialize<logproto_pb.TailRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.TailRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.TailResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.TailResponse>;
+interface IQuerierService_ITail
+	extends grpc.MethodDefinition<
+		logproto_pb.TailRequest,
+		logproto_pb.TailResponse
+	> {
+	path: '/logproto.Querier/Tail';
+	requestStream: false;
+	responseStream: true;
+	requestSerialize: grpc.serialize<logproto_pb.TailRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.TailRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.TailResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.TailResponse>;
 }
-interface IQuerierService_ISeries extends grpc.MethodDefinition<logproto_pb.SeriesRequest, logproto_pb.SeriesResponse> {
-    path: string; // "/logproto.Querier/Series"
-    requestStream: boolean; // false
-    responseStream: boolean; // false
-    requestSerialize: grpc.serialize<logproto_pb.SeriesRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.SeriesRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.SeriesResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.SeriesResponse>;
+interface IQuerierService_ISeries
+	extends grpc.MethodDefinition<
+		logproto_pb.SeriesRequest,
+		logproto_pb.SeriesResponse
+	> {
+	path: '/logproto.Querier/Series';
+	requestStream: false;
+	responseStream: false;
+	requestSerialize: grpc.serialize<logproto_pb.SeriesRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.SeriesRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.SeriesResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.SeriesResponse>;
 }
-interface IQuerierService_ITailersCount extends grpc.MethodDefinition<logproto_pb.TailersCountRequest, logproto_pb.TailersCountResponse> {
-    path: string; // "/logproto.Querier/TailersCount"
-    requestStream: boolean; // false
-    responseStream: boolean; // false
-    requestSerialize: grpc.serialize<logproto_pb.TailersCountRequest>;
-    requestDeserialize: grpc.deserialize<logproto_pb.TailersCountRequest>;
-    responseSerialize: grpc.serialize<logproto_pb.TailersCountResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.TailersCountResponse>;
+interface IQuerierService_ITailersCount
+	extends grpc.MethodDefinition<
+		logproto_pb.TailersCountRequest,
+		logproto_pb.TailersCountResponse
+	> {
+	path: '/logproto.Querier/TailersCount';
+	requestStream: false;
+	responseStream: false;
+	requestSerialize: grpc.serialize<logproto_pb.TailersCountRequest>;
+	requestDeserialize: grpc.deserialize<logproto_pb.TailersCountRequest>;
+	responseSerialize: grpc.serialize<logproto_pb.TailersCountResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.TailersCountResponse>;
 }
 
 export const QuerierService: IQuerierService;
 
-export interface IQuerierServer {
-    query: grpc.handleServerStreamingCall<logproto_pb.QueryRequest, logproto_pb.QueryResponse>;
-    label: grpc.handleUnaryCall<logproto_pb.LabelRequest, logproto_pb.LabelResponse>;
-    tail: grpc.handleServerStreamingCall<logproto_pb.TailRequest, logproto_pb.TailResponse>;
-    series: grpc.handleUnaryCall<logproto_pb.SeriesRequest, logproto_pb.SeriesResponse>;
-    tailersCount: grpc.handleUnaryCall<logproto_pb.TailersCountRequest, logproto_pb.TailersCountResponse>;
+export interface IQuerierServer extends grpc.UntypedServiceImplementation {
+	query: grpc.handleServerStreamingCall<
+		logproto_pb.QueryRequest,
+		logproto_pb.QueryResponse
+	>;
+	label: grpc.handleUnaryCall<
+		logproto_pb.LabelRequest,
+		logproto_pb.LabelResponse
+	>;
+	tail: grpc.handleServerStreamingCall<
+		logproto_pb.TailRequest,
+		logproto_pb.TailResponse
+	>;
+	series: grpc.handleUnaryCall<
+		logproto_pb.SeriesRequest,
+		logproto_pb.SeriesResponse
+	>;
+	tailersCount: grpc.handleUnaryCall<
+		logproto_pb.TailersCountRequest,
+		logproto_pb.TailersCountResponse
+	>;
 }
 
 export interface IQuerierClient {
-    query(request: logproto_pb.QueryRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
-    query(request: logproto_pb.QueryRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
-    label(request: logproto_pb.LabelRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    label(request: logproto_pb.LabelRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    label(request: logproto_pb.LabelRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    tail(request: logproto_pb.TailRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.TailResponse>;
-    tail(request: logproto_pb.TailRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.TailResponse>;
-    series(request: logproto_pb.SeriesRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    series(request: logproto_pb.SeriesRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    series(request: logproto_pb.SeriesRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    tailersCount(request: logproto_pb.TailersCountRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
-    tailersCount(request: logproto_pb.TailersCountRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
-    tailersCount(request: logproto_pb.TailersCountRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
+	query(
+		request: logproto_pb.QueryRequest,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
+	query(
+		request: logproto_pb.QueryRequest,
+		metadata?: grpc.Metadata,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
+	label(
+		request: logproto_pb.LabelRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	label(
+		request: logproto_pb.LabelRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	label(
+		request: logproto_pb.LabelRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	tail(
+		request: logproto_pb.TailRequest,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.TailResponse>;
+	tail(
+		request: logproto_pb.TailRequest,
+		metadata?: grpc.Metadata,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.TailResponse>;
+	series(
+		request: logproto_pb.SeriesRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	series(
+		request: logproto_pb.SeriesRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	series(
+		request: logproto_pb.SeriesRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
 }
 
 export class QuerierClient extends grpc.Client implements IQuerierClient {
-    constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
-    public query(request: logproto_pb.QueryRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
-    public query(request: logproto_pb.QueryRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
-    public label(request: logproto_pb.LabelRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    public label(request: logproto_pb.LabelRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    public label(request: logproto_pb.LabelRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.LabelResponse) => void): grpc.ClientUnaryCall;
-    public tail(request: logproto_pb.TailRequest, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.TailResponse>;
-    public tail(request: logproto_pb.TailRequest, metadata?: grpc.Metadata, options?: Partial<grpc.CallOptions>): grpc.ClientReadableStream<logproto_pb.TailResponse>;
-    public series(request: logproto_pb.SeriesRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    public series(request: logproto_pb.SeriesRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    public series(request: logproto_pb.SeriesRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.SeriesResponse) => void): grpc.ClientUnaryCall;
-    public tailersCount(request: logproto_pb.TailersCountRequest, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
-    public tailersCount(request: logproto_pb.TailersCountRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
-    public tailersCount(request: logproto_pb.TailersCountRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TailersCountResponse) => void): grpc.ClientUnaryCall;
+	constructor(
+		address: string,
+		credentials: grpc.ChannelCredentials,
+		options?: Partial<grpc.ClientOptions>,
+	);
+	public query(
+		request: logproto_pb.QueryRequest,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
+	public query(
+		request: logproto_pb.QueryRequest,
+		metadata?: grpc.Metadata,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.QueryResponse>;
+	public label(
+		request: logproto_pb.LabelRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public label(
+		request: logproto_pb.LabelRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public label(
+		request: logproto_pb.LabelRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.LabelResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public tail(
+		request: logproto_pb.TailRequest,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.TailResponse>;
+	public tail(
+		request: logproto_pb.TailRequest,
+		metadata?: grpc.Metadata,
+		options?: Partial<grpc.CallOptions>,
+	): grpc.ClientReadableStream<logproto_pb.TailResponse>;
+	public series(
+		request: logproto_pb.SeriesRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public series(
+		request: logproto_pb.SeriesRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public series(
+		request: logproto_pb.SeriesRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.SeriesResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
+	public tailersCount(
+		request: logproto_pb.TailersCountRequest,
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TailersCountResponse,
+		) => void,
+	): grpc.ClientUnaryCall;
 }
 
-interface IIngesterService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
-    transferChunks: IIngesterService_ITransferChunks;
+interface IIngesterService
+	extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
+	transferChunks: IIngesterService_ITransferChunks;
 }
 
-interface IIngesterService_ITransferChunks extends grpc.MethodDefinition<logproto_pb.TimeSeriesChunk, logproto_pb.TransferChunksResponse> {
-    path: string; // "/logproto.Ingester/TransferChunks"
-    requestStream: boolean; // true
-    responseStream: boolean; // false
-    requestSerialize: grpc.serialize<logproto_pb.TimeSeriesChunk>;
-    requestDeserialize: grpc.deserialize<logproto_pb.TimeSeriesChunk>;
-    responseSerialize: grpc.serialize<logproto_pb.TransferChunksResponse>;
-    responseDeserialize: grpc.deserialize<logproto_pb.TransferChunksResponse>;
+interface IIngesterService_ITransferChunks
+	extends grpc.MethodDefinition<
+		logproto_pb.TimeSeriesChunk,
+		logproto_pb.TransferChunksResponse
+	> {
+	path: '/logproto.Ingester/TransferChunks';
+	requestStream: true;
+	responseStream: false;
+	requestSerialize: grpc.serialize<logproto_pb.TimeSeriesChunk>;
+	requestDeserialize: grpc.deserialize<logproto_pb.TimeSeriesChunk>;
+	responseSerialize: grpc.serialize<logproto_pb.TransferChunksResponse>;
+	responseDeserialize: grpc.deserialize<logproto_pb.TransferChunksResponse>;
 }
 
 export const IngesterService: IIngesterService;
 
-export interface IIngesterServer {
-    transferChunks: grpc.handleClientStreamingCall<logproto_pb.TimeSeriesChunk, logproto_pb.TransferChunksResponse>;
+export interface IIngesterServer extends grpc.UntypedServiceImplementation {
+	transferChunks: grpc.handleClientStreamingCall<
+		logproto_pb.TimeSeriesChunk,
+		logproto_pb.TransferChunksResponse
+	>;
 }
 
 export interface IIngesterClient {
-    transferChunks(callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    transferChunks(metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    transferChunks(options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    transferChunks(metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	transferChunks(
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	transferChunks(
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	transferChunks(
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	transferChunks(
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
 }
 
 export class IngesterClient extends grpc.Client implements IIngesterClient {
-    constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
-    public transferChunks(callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    public transferChunks(metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    public transferChunks(options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
-    public transferChunks(metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: logproto_pb.TransferChunksResponse) => void): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	constructor(
+		address: string,
+		credentials: grpc.ChannelCredentials,
+		options?: Partial<grpc.ClientOptions>,
+	);
+	public transferChunks(
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	public transferChunks(
+		metadata: grpc.Metadata,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	public transferChunks(
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
+	public transferChunks(
+		metadata: grpc.Metadata,
+		options: Partial<grpc.CallOptions>,
+		callback: (
+			error: grpc.ServiceError | null,
+			response: logproto_pb.TransferChunksResponse,
+		) => void,
+	): grpc.ClientWritableStream<logproto_pb.TimeSeriesChunk>;
 }

--- a/proto/compiled/logproto_grpc_pb.js
+++ b/proto/compiled/logproto_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var logproto_pb = require('./logproto_pb.js');
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 var gogo_pb = require('./gogo_pb.js');

--- a/proto/compiled/logproto_pb.d.ts
+++ b/proto/compiled/logproto_pb.d.ts
@@ -4,558 +4,722 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import * as jspb from "google-protobuf";
-import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb";
-import * as gogo_pb from "./gogo_pb";
+import * as jspb from 'google-protobuf';
+import * as google_protobuf_timestamp_pb from 'google-protobuf/google/protobuf/timestamp_pb';
+import * as gogo_pb from './gogo_pb';
 
-export class PushRequest extends jspb.Message { 
-    clearStreamsList(): void;
-    getStreamsList(): Array<StreamAdapter>;
-    setStreamsList(value: Array<StreamAdapter>): PushRequest;
-    addStreams(value?: StreamAdapter, index?: number): StreamAdapter;
+export class PushRequest extends jspb.Message {
+	clearStreamsList(): void;
+	getStreamsList(): Array<StreamAdapter>;
+	setStreamsList(value: Array<StreamAdapter>): PushRequest;
+	addStreams(value?: StreamAdapter, index?: number): StreamAdapter;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PushRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PushRequest): PushRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PushRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PushRequest;
-    static deserializeBinaryFromReader(message: PushRequest, reader: jspb.BinaryReader): PushRequest;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): PushRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: PushRequest,
+	): PushRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: PushRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): PushRequest;
+	static deserializeBinaryFromReader(
+		message: PushRequest,
+		reader: jspb.BinaryReader,
+	): PushRequest;
 }
 
 export namespace PushRequest {
-    export type AsObject = {
-        streamsList: Array<StreamAdapter.AsObject>,
-    }
+	export type AsObject = {
+		streamsList: Array<StreamAdapter.AsObject>;
+	};
 }
 
-export class PushResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PushResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PushResponse): PushResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PushResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PushResponse;
-    static deserializeBinaryFromReader(message: PushResponse, reader: jspb.BinaryReader): PushResponse;
+export class PushResponse extends jspb.Message {
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): PushResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: PushResponse,
+	): PushResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: PushResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): PushResponse;
+	static deserializeBinaryFromReader(
+		message: PushResponse,
+		reader: jspb.BinaryReader,
+	): PushResponse;
 }
 
 export namespace PushResponse {
-    export type AsObject = {
-    }
+	export type AsObject = {};
 }
 
-export class QueryRequest extends jspb.Message { 
-    getSelector(): string;
-    setSelector(value: string): QueryRequest;
+export class QueryRequest extends jspb.Message {
+	getSelector(): string;
+	setSelector(value: string): QueryRequest;
+	getLimit(): number;
+	setLimit(value: number): QueryRequest;
 
-    getLimit(): number;
-    setLimit(value: number): QueryRequest;
+	hasStart(): boolean;
+	clearStart(): void;
+	getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setStart(value?: google_protobuf_timestamp_pb.Timestamp): QueryRequest;
 
+	hasEnd(): boolean;
+	clearEnd(): void;
+	getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setEnd(value?: google_protobuf_timestamp_pb.Timestamp): QueryRequest;
+	getDirection(): Direction;
+	setDirection(value: Direction): QueryRequest;
 
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setStart(value?: google_protobuf_timestamp_pb.Timestamp): QueryRequest;
-
-
-    hasEnd(): boolean;
-    clearEnd(): void;
-    getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setEnd(value?: google_protobuf_timestamp_pb.Timestamp): QueryRequest;
-
-    getDirection(): Direction;
-    setDirection(value: Direction): QueryRequest;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryRequest): QueryRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryRequest;
-    static deserializeBinaryFromReader(message: QueryRequest, reader: jspb.BinaryReader): QueryRequest;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): QueryRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: QueryRequest,
+	): QueryRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: QueryRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): QueryRequest;
+	static deserializeBinaryFromReader(
+		message: QueryRequest,
+		reader: jspb.BinaryReader,
+	): QueryRequest;
 }
 
 export namespace QueryRequest {
-    export type AsObject = {
-        selector: string,
-        limit: number,
-        start?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        end?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        direction: Direction,
-    }
+	export type AsObject = {
+		selector: string;
+		limit: number;
+		start?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		end?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		direction: Direction;
+	};
 }
 
-export class QueryResponse extends jspb.Message { 
-    clearStreamsList(): void;
-    getStreamsList(): Array<StreamAdapter>;
-    setStreamsList(value: Array<StreamAdapter>): QueryResponse;
-    addStreams(value?: StreamAdapter, index?: number): StreamAdapter;
+export class QueryResponse extends jspb.Message {
+	clearStreamsList(): void;
+	getStreamsList(): Array<StreamAdapter>;
+	setStreamsList(value: Array<StreamAdapter>): QueryResponse;
+	addStreams(value?: StreamAdapter, index?: number): StreamAdapter;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryResponse): QueryResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryResponse;
-    static deserializeBinaryFromReader(message: QueryResponse, reader: jspb.BinaryReader): QueryResponse;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): QueryResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: QueryResponse,
+	): QueryResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: QueryResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): QueryResponse;
+	static deserializeBinaryFromReader(
+		message: QueryResponse,
+		reader: jspb.BinaryReader,
+	): QueryResponse;
 }
 
 export namespace QueryResponse {
-    export type AsObject = {
-        streamsList: Array<StreamAdapter.AsObject>,
-    }
+	export type AsObject = {
+		streamsList: Array<StreamAdapter.AsObject>;
+	};
 }
 
-export class LabelRequest extends jspb.Message { 
-    getName(): string;
-    setName(value: string): LabelRequest;
+export class LabelRequest extends jspb.Message {
+	getName(): string;
+	setName(value: string): LabelRequest;
+	getValues(): boolean;
+	setValues(value: boolean): LabelRequest;
 
-    getValues(): boolean;
-    setValues(value: boolean): LabelRequest;
+	hasStart(): boolean;
+	clearStart(): void;
+	getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setStart(value?: google_protobuf_timestamp_pb.Timestamp): LabelRequest;
 
+	hasEnd(): boolean;
+	clearEnd(): void;
+	getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setEnd(value?: google_protobuf_timestamp_pb.Timestamp): LabelRequest;
 
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setStart(value?: google_protobuf_timestamp_pb.Timestamp): LabelRequest;
-
-
-    hasEnd(): boolean;
-    clearEnd(): void;
-    getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setEnd(value?: google_protobuf_timestamp_pb.Timestamp): LabelRequest;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LabelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: LabelRequest): LabelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LabelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LabelRequest;
-    static deserializeBinaryFromReader(message: LabelRequest, reader: jspb.BinaryReader): LabelRequest;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): LabelRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: LabelRequest,
+	): LabelRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: LabelRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): LabelRequest;
+	static deserializeBinaryFromReader(
+		message: LabelRequest,
+		reader: jspb.BinaryReader,
+	): LabelRequest;
 }
 
 export namespace LabelRequest {
-    export type AsObject = {
-        name: string,
-        values: boolean,
-        start?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        end?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-    }
+	export type AsObject = {
+		name: string;
+		values: boolean;
+		start?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		end?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+	};
 }
 
-export class LabelResponse extends jspb.Message { 
-    clearValuesList(): void;
-    getValuesList(): Array<string>;
-    setValuesList(value: Array<string>): LabelResponse;
-    addValues(value: string, index?: number): string;
+export class LabelResponse extends jspb.Message {
+	clearValuesList(): void;
+	getValuesList(): Array<string>;
+	setValuesList(value: Array<string>): LabelResponse;
+	addValues(value: string, index?: number): string;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LabelResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: LabelResponse): LabelResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LabelResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LabelResponse;
-    static deserializeBinaryFromReader(message: LabelResponse, reader: jspb.BinaryReader): LabelResponse;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): LabelResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: LabelResponse,
+	): LabelResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: LabelResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): LabelResponse;
+	static deserializeBinaryFromReader(
+		message: LabelResponse,
+		reader: jspb.BinaryReader,
+	): LabelResponse;
 }
 
 export namespace LabelResponse {
-    export type AsObject = {
-        valuesList: Array<string>,
-    }
+	export type AsObject = {
+		valuesList: Array<string>;
+	};
 }
 
-export class StreamAdapter extends jspb.Message { 
-    getLabels(): string;
-    setLabels(value: string): StreamAdapter;
+export class StreamAdapter extends jspb.Message {
+	getLabels(): string;
+	setLabels(value: string): StreamAdapter;
+	clearEntriesList(): void;
+	getEntriesList(): Array<EntryAdapter>;
+	setEntriesList(value: Array<EntryAdapter>): StreamAdapter;
+	addEntries(value?: EntryAdapter, index?: number): EntryAdapter;
 
-    clearEntriesList(): void;
-    getEntriesList(): Array<EntryAdapter>;
-    setEntriesList(value: Array<EntryAdapter>): StreamAdapter;
-    addEntries(value?: EntryAdapter, index?: number): EntryAdapter;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): StreamAdapter.AsObject;
-    static toObject(includeInstance: boolean, msg: StreamAdapter): StreamAdapter.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: StreamAdapter, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): StreamAdapter;
-    static deserializeBinaryFromReader(message: StreamAdapter, reader: jspb.BinaryReader): StreamAdapter;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): StreamAdapter.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: StreamAdapter,
+	): StreamAdapter.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: StreamAdapter,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): StreamAdapter;
+	static deserializeBinaryFromReader(
+		message: StreamAdapter,
+		reader: jspb.BinaryReader,
+	): StreamAdapter;
 }
 
 export namespace StreamAdapter {
-    export type AsObject = {
-        labels: string,
-        entriesList: Array<EntryAdapter.AsObject>,
-    }
+	export type AsObject = {
+		labels: string;
+		entriesList: Array<EntryAdapter.AsObject>;
+	};
 }
 
-export class EntryAdapter extends jspb.Message { 
+export class EntryAdapter extends jspb.Message {
+	hasTimestamp(): boolean;
+	clearTimestamp(): void;
+	getTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): EntryAdapter;
+	getLine(): string;
+	setLine(value: string): EntryAdapter;
 
-    hasTimestamp(): boolean;
-    clearTimestamp(): void;
-    getTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): EntryAdapter;
-
-    getLine(): string;
-    setLine(value: string): EntryAdapter;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EntryAdapter.AsObject;
-    static toObject(includeInstance: boolean, msg: EntryAdapter): EntryAdapter.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EntryAdapter, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EntryAdapter;
-    static deserializeBinaryFromReader(message: EntryAdapter, reader: jspb.BinaryReader): EntryAdapter;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): EntryAdapter.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: EntryAdapter,
+	): EntryAdapter.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: EntryAdapter,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): EntryAdapter;
+	static deserializeBinaryFromReader(
+		message: EntryAdapter,
+		reader: jspb.BinaryReader,
+	): EntryAdapter;
 }
 
 export namespace EntryAdapter {
-    export type AsObject = {
-        timestamp?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        line: string,
-    }
+	export type AsObject = {
+		timestamp?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		line: string;
+	};
 }
 
-export class TailRequest extends jspb.Message { 
-    getQuery(): string;
-    setQuery(value: string): TailRequest;
+export class TailRequest extends jspb.Message {
+	getQuery(): string;
+	setQuery(value: string): TailRequest;
+	getDelayfor(): number;
+	setDelayfor(value: number): TailRequest;
+	getLimit(): number;
+	setLimit(value: number): TailRequest;
 
-    getDelayfor(): number;
-    setDelayfor(value: number): TailRequest;
+	hasStart(): boolean;
+	clearStart(): void;
+	getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setStart(value?: google_protobuf_timestamp_pb.Timestamp): TailRequest;
 
-    getLimit(): number;
-    setLimit(value: number): TailRequest;
-
-
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setStart(value?: google_protobuf_timestamp_pb.Timestamp): TailRequest;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TailRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: TailRequest): TailRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TailRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TailRequest;
-    static deserializeBinaryFromReader(message: TailRequest, reader: jspb.BinaryReader): TailRequest;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TailRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TailRequest,
+	): TailRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TailRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TailRequest;
+	static deserializeBinaryFromReader(
+		message: TailRequest,
+		reader: jspb.BinaryReader,
+	): TailRequest;
 }
 
 export namespace TailRequest {
-    export type AsObject = {
-        query: string,
-        delayfor: number,
-        limit: number,
-        start?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-    }
+	export type AsObject = {
+		query: string;
+		delayfor: number;
+		limit: number;
+		start?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+	};
 }
 
-export class TailResponse extends jspb.Message { 
+export class TailResponse extends jspb.Message {
+	hasStream(): boolean;
+	clearStream(): void;
+	getStream(): StreamAdapter | undefined;
+	setStream(value?: StreamAdapter): TailResponse;
+	clearDroppedstreamsList(): void;
+	getDroppedstreamsList(): Array<DroppedStream>;
+	setDroppedstreamsList(value: Array<DroppedStream>): TailResponse;
+	addDroppedstreams(value?: DroppedStream, index?: number): DroppedStream;
 
-    hasStream(): boolean;
-    clearStream(): void;
-    getStream(): StreamAdapter | undefined;
-    setStream(value?: StreamAdapter): TailResponse;
-
-    clearDroppedstreamsList(): void;
-    getDroppedstreamsList(): Array<DroppedStream>;
-    setDroppedstreamsList(value: Array<DroppedStream>): TailResponse;
-    addDroppedstreams(value?: DroppedStream, index?: number): DroppedStream;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TailResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: TailResponse): TailResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TailResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TailResponse;
-    static deserializeBinaryFromReader(message: TailResponse, reader: jspb.BinaryReader): TailResponse;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TailResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TailResponse,
+	): TailResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TailResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TailResponse;
+	static deserializeBinaryFromReader(
+		message: TailResponse,
+		reader: jspb.BinaryReader,
+	): TailResponse;
 }
 
 export namespace TailResponse {
-    export type AsObject = {
-        stream?: StreamAdapter.AsObject,
-        droppedstreamsList: Array<DroppedStream.AsObject>,
-    }
+	export type AsObject = {
+		stream?: StreamAdapter.AsObject;
+		droppedstreamsList: Array<DroppedStream.AsObject>;
+	};
 }
 
-export class SeriesRequest extends jspb.Message { 
+export class SeriesRequest extends jspb.Message {
+	hasStart(): boolean;
+	clearStart(): void;
+	getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setStart(value?: google_protobuf_timestamp_pb.Timestamp): SeriesRequest;
 
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setStart(value?: google_protobuf_timestamp_pb.Timestamp): SeriesRequest;
+	hasEnd(): boolean;
+	clearEnd(): void;
+	getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setEnd(value?: google_protobuf_timestamp_pb.Timestamp): SeriesRequest;
+	clearGroupsList(): void;
+	getGroupsList(): Array<string>;
+	setGroupsList(value: Array<string>): SeriesRequest;
+	addGroups(value: string, index?: number): string;
 
-
-    hasEnd(): boolean;
-    clearEnd(): void;
-    getEnd(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setEnd(value?: google_protobuf_timestamp_pb.Timestamp): SeriesRequest;
-
-    clearGroupsList(): void;
-    getGroupsList(): Array<string>;
-    setGroupsList(value: Array<string>): SeriesRequest;
-    addGroups(value: string, index?: number): string;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SeriesRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SeriesRequest): SeriesRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SeriesRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SeriesRequest;
-    static deserializeBinaryFromReader(message: SeriesRequest, reader: jspb.BinaryReader): SeriesRequest;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): SeriesRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: SeriesRequest,
+	): SeriesRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: SeriesRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): SeriesRequest;
+	static deserializeBinaryFromReader(
+		message: SeriesRequest,
+		reader: jspb.BinaryReader,
+	): SeriesRequest;
 }
 
 export namespace SeriesRequest {
-    export type AsObject = {
-        start?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        end?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        groupsList: Array<string>,
-    }
+	export type AsObject = {
+		start?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		end?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		groupsList: Array<string>;
+	};
 }
 
-export class SeriesResponse extends jspb.Message { 
-    clearSeriesList(): void;
-    getSeriesList(): Array<SeriesIdentifier>;
-    setSeriesList(value: Array<SeriesIdentifier>): SeriesResponse;
-    addSeries(value?: SeriesIdentifier, index?: number): SeriesIdentifier;
+export class SeriesResponse extends jspb.Message {
+	clearSeriesList(): void;
+	getSeriesList(): Array<SeriesIdentifier>;
+	setSeriesList(value: Array<SeriesIdentifier>): SeriesResponse;
+	addSeries(value?: SeriesIdentifier, index?: number): SeriesIdentifier;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SeriesResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SeriesResponse): SeriesResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SeriesResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SeriesResponse;
-    static deserializeBinaryFromReader(message: SeriesResponse, reader: jspb.BinaryReader): SeriesResponse;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): SeriesResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: SeriesResponse,
+	): SeriesResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: SeriesResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): SeriesResponse;
+	static deserializeBinaryFromReader(
+		message: SeriesResponse,
+		reader: jspb.BinaryReader,
+	): SeriesResponse;
 }
 
 export namespace SeriesResponse {
-    export type AsObject = {
-        seriesList: Array<SeriesIdentifier.AsObject>,
-    }
+	export type AsObject = {
+		seriesList: Array<SeriesIdentifier.AsObject>;
+	};
 }
 
-export class SeriesIdentifier extends jspb.Message { 
+export class SeriesIdentifier extends jspb.Message {
+	getLabelsMap(): jspb.Map<string, string>;
+	clearLabelsMap(): void;
 
-    getLabelsMap(): jspb.Map<string, string>;
-    clearLabelsMap(): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SeriesIdentifier.AsObject;
-    static toObject(includeInstance: boolean, msg: SeriesIdentifier): SeriesIdentifier.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SeriesIdentifier, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SeriesIdentifier;
-    static deserializeBinaryFromReader(message: SeriesIdentifier, reader: jspb.BinaryReader): SeriesIdentifier;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): SeriesIdentifier.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: SeriesIdentifier,
+	): SeriesIdentifier.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: SeriesIdentifier,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): SeriesIdentifier;
+	static deserializeBinaryFromReader(
+		message: SeriesIdentifier,
+		reader: jspb.BinaryReader,
+	): SeriesIdentifier;
 }
 
 export namespace SeriesIdentifier {
-    export type AsObject = {
-
-        labelsMap: Array<[string, string]>,
-    }
+	export type AsObject = {
+		labelsMap: Array<[string, string]>;
+	};
 }
 
-export class DroppedStream extends jspb.Message { 
+export class DroppedStream extends jspb.Message {
+	hasFrom(): boolean;
+	clearFrom(): void;
+	getFrom(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setFrom(value?: google_protobuf_timestamp_pb.Timestamp): DroppedStream;
 
-    hasFrom(): boolean;
-    clearFrom(): void;
-    getFrom(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setFrom(value?: google_protobuf_timestamp_pb.Timestamp): DroppedStream;
+	hasTo(): boolean;
+	clearTo(): void;
+	getTo(): google_protobuf_timestamp_pb.Timestamp | undefined;
+	setTo(value?: google_protobuf_timestamp_pb.Timestamp): DroppedStream;
+	getLabels(): string;
+	setLabels(value: string): DroppedStream;
 
-
-    hasTo(): boolean;
-    clearTo(): void;
-    getTo(): google_protobuf_timestamp_pb.Timestamp | undefined;
-    setTo(value?: google_protobuf_timestamp_pb.Timestamp): DroppedStream;
-
-    getLabels(): string;
-    setLabels(value: string): DroppedStream;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DroppedStream.AsObject;
-    static toObject(includeInstance: boolean, msg: DroppedStream): DroppedStream.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DroppedStream, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DroppedStream;
-    static deserializeBinaryFromReader(message: DroppedStream, reader: jspb.BinaryReader): DroppedStream;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): DroppedStream.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: DroppedStream,
+	): DroppedStream.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: DroppedStream,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): DroppedStream;
+	static deserializeBinaryFromReader(
+		message: DroppedStream,
+		reader: jspb.BinaryReader,
+	): DroppedStream;
 }
 
 export namespace DroppedStream {
-    export type AsObject = {
-        from?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        to?: google_protobuf_timestamp_pb.Timestamp.AsObject,
-        labels: string,
-    }
+	export type AsObject = {
+		from?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		to?: google_protobuf_timestamp_pb.Timestamp.AsObject;
+		labels: string;
+	};
 }
 
-export class TimeSeriesChunk extends jspb.Message { 
-    getFromIngesterId(): string;
-    setFromIngesterId(value: string): TimeSeriesChunk;
+export class TimeSeriesChunk extends jspb.Message {
+	getFromIngesterId(): string;
+	setFromIngesterId(value: string): TimeSeriesChunk;
+	getUserId(): string;
+	setUserId(value: string): TimeSeriesChunk;
+	clearLabelsList(): void;
+	getLabelsList(): Array<LabelPair>;
+	setLabelsList(value: Array<LabelPair>): TimeSeriesChunk;
+	addLabels(value?: LabelPair, index?: number): LabelPair;
+	clearChunksList(): void;
+	getChunksList(): Array<Chunk>;
+	setChunksList(value: Array<Chunk>): TimeSeriesChunk;
+	addChunks(value?: Chunk, index?: number): Chunk;
 
-    getUserId(): string;
-    setUserId(value: string): TimeSeriesChunk;
-
-    clearLabelsList(): void;
-    getLabelsList(): Array<LabelPair>;
-    setLabelsList(value: Array<LabelPair>): TimeSeriesChunk;
-    addLabels(value?: LabelPair, index?: number): LabelPair;
-
-    clearChunksList(): void;
-    getChunksList(): Array<Chunk>;
-    setChunksList(value: Array<Chunk>): TimeSeriesChunk;
-    addChunks(value?: Chunk, index?: number): Chunk;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TimeSeriesChunk.AsObject;
-    static toObject(includeInstance: boolean, msg: TimeSeriesChunk): TimeSeriesChunk.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TimeSeriesChunk, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TimeSeriesChunk;
-    static deserializeBinaryFromReader(message: TimeSeriesChunk, reader: jspb.BinaryReader): TimeSeriesChunk;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TimeSeriesChunk.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TimeSeriesChunk,
+	): TimeSeriesChunk.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TimeSeriesChunk,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TimeSeriesChunk;
+	static deserializeBinaryFromReader(
+		message: TimeSeriesChunk,
+		reader: jspb.BinaryReader,
+	): TimeSeriesChunk;
 }
 
 export namespace TimeSeriesChunk {
-    export type AsObject = {
-        fromIngesterId: string,
-        userId: string,
-        labelsList: Array<LabelPair.AsObject>,
-        chunksList: Array<Chunk.AsObject>,
-    }
+	export type AsObject = {
+		fromIngesterId: string;
+		userId: string;
+		labelsList: Array<LabelPair.AsObject>;
+		chunksList: Array<Chunk.AsObject>;
+	};
 }
 
-export class LabelPair extends jspb.Message { 
-    getName(): string;
-    setName(value: string): LabelPair;
+export class LabelPair extends jspb.Message {
+	getName(): string;
+	setName(value: string): LabelPair;
+	getValue(): string;
+	setValue(value: string): LabelPair;
 
-    getValue(): string;
-    setValue(value: string): LabelPair;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LabelPair.AsObject;
-    static toObject(includeInstance: boolean, msg: LabelPair): LabelPair.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LabelPair, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LabelPair;
-    static deserializeBinaryFromReader(message: LabelPair, reader: jspb.BinaryReader): LabelPair;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): LabelPair.AsObject;
+	static toObject(includeInstance: boolean, msg: LabelPair): LabelPair.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: LabelPair,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): LabelPair;
+	static deserializeBinaryFromReader(
+		message: LabelPair,
+		reader: jspb.BinaryReader,
+	): LabelPair;
 }
 
 export namespace LabelPair {
-    export type AsObject = {
-        name: string,
-        value: string,
-    }
+	export type AsObject = {
+		name: string;
+		value: string;
+	};
 }
 
-export class Chunk extends jspb.Message { 
-    getData(): Uint8Array | string;
-    getData_asU8(): Uint8Array;
-    getData_asB64(): string;
-    setData(value: Uint8Array | string): Chunk;
+export class Chunk extends jspb.Message {
+	getData(): Uint8Array | string;
+	getData_asU8(): Uint8Array;
+	getData_asB64(): string;
+	setData(value: Uint8Array | string): Chunk;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Chunk.AsObject;
-    static toObject(includeInstance: boolean, msg: Chunk): Chunk.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Chunk, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Chunk;
-    static deserializeBinaryFromReader(message: Chunk, reader: jspb.BinaryReader): Chunk;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): Chunk.AsObject;
+	static toObject(includeInstance: boolean, msg: Chunk): Chunk.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: Chunk,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): Chunk;
+	static deserializeBinaryFromReader(
+		message: Chunk,
+		reader: jspb.BinaryReader,
+	): Chunk;
 }
 
 export namespace Chunk {
-    export type AsObject = {
-        data: Uint8Array | string,
-    }
+	export type AsObject = {
+		data: Uint8Array | string;
+	};
 }
 
-export class TransferChunksResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TransferChunksResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: TransferChunksResponse): TransferChunksResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TransferChunksResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TransferChunksResponse;
-    static deserializeBinaryFromReader(message: TransferChunksResponse, reader: jspb.BinaryReader): TransferChunksResponse;
+export class TransferChunksResponse extends jspb.Message {
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TransferChunksResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TransferChunksResponse,
+	): TransferChunksResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TransferChunksResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TransferChunksResponse;
+	static deserializeBinaryFromReader(
+		message: TransferChunksResponse,
+		reader: jspb.BinaryReader,
+	): TransferChunksResponse;
 }
 
 export namespace TransferChunksResponse {
-    export type AsObject = {
-    }
+	export type AsObject = {};
 }
 
-export class TailersCountRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TailersCountRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: TailersCountRequest): TailersCountRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TailersCountRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TailersCountRequest;
-    static deserializeBinaryFromReader(message: TailersCountRequest, reader: jspb.BinaryReader): TailersCountRequest;
+export class TailersCountRequest extends jspb.Message {
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TailersCountRequest.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TailersCountRequest,
+	): TailersCountRequest.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TailersCountRequest,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TailersCountRequest;
+	static deserializeBinaryFromReader(
+		message: TailersCountRequest,
+		reader: jspb.BinaryReader,
+	): TailersCountRequest;
 }
 
 export namespace TailersCountRequest {
-    export type AsObject = {
-    }
+	export type AsObject = {};
 }
 
-export class TailersCountResponse extends jspb.Message { 
-    getCount(): number;
-    setCount(value: number): TailersCountResponse;
+export class TailersCountResponse extends jspb.Message {
+	getCount(): number;
+	setCount(value: number): TailersCountResponse;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TailersCountResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: TailersCountResponse): TailersCountResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TailersCountResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TailersCountResponse;
-    static deserializeBinaryFromReader(message: TailersCountResponse, reader: jspb.BinaryReader): TailersCountResponse;
+	serializeBinary(): Uint8Array;
+	toObject(includeInstance?: boolean): TailersCountResponse.AsObject;
+	static toObject(
+		includeInstance: boolean,
+		msg: TailersCountResponse,
+	): TailersCountResponse.AsObject;
+	static extensions: { [key: number]: jspb.ExtensionFieldInfo<jspb.Message> };
+	static extensionsBinary: {
+		[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>;
+	};
+	static serializeBinaryToWriter(
+		message: TailersCountResponse,
+		writer: jspb.BinaryWriter,
+	): void;
+	static deserializeBinary(bytes: Uint8Array): TailersCountResponse;
+	static deserializeBinaryFromReader(
+		message: TailersCountResponse,
+		reader: jspb.BinaryReader,
+	): TailersCountResponse;
 }
 
 export namespace TailersCountResponse {
-    export type AsObject = {
-        count: number,
-    }
+	export type AsObject = {
+		count: number;
+	};
 }
 
 export enum Direction {
-    FORWARD = 0,
-    BACKWARD = 1,
+	FORWARD = 0,
+	BACKWARD = 1,
 }

--- a/proto/compiled/logproto_pb.js
+++ b/proto/compiled/logproto_pb.js
@@ -2,11 +2,14 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,9 @@
-import * as grpc from 'grpc';
-import { CallOptions, Metadata } from 'grpc';
-import { promisify } from 'util';
+import * as grpc from '@grpc/grpc-js';
 
-export {
-	status,
-	ClientReadableStream,
-	ServiceError,
-	Metadata,
-	CallOptions,
-} from 'grpc';
+export { status, ClientReadableStream, ServiceError } from '@grpc/grpc-js';
 export * from 'google-protobuf/google/protobuf/timestamp_pb.js';
 export * from '../proto/compiled/logproto_grpc_pb';
 export * from '../proto/compiled/logproto_pb';
-
-export interface IGrpcClientAsync {
-	[key: string]: IGrpcMethod;
-}
-
-export type IGrpcMethod = (
-	data: any,
-	metadata?: Metadata,
-	options?: CallOptions,
-) => Promise<any>;
-
-export function promisifyClient(client: any): IGrpcClientAsync {
-	const promisifiedClient = {} as IGrpcClientAsync;
-	for (const name of Object.values<string>(client.$method_names)) {
-		promisifiedClient[name] = promisify(client[name].bind(client));
-	}
-	return promisifiedClient;
-}
 
 export function createInsecureCredentials() {
 	return grpc.credentials.createInsecure();


### PR DESCRIPTION
Removed `promisifyClient` function, not compatible with `grpc-js` replace with promisify on client methods.
Rebuilt proto js to use `grpc-js`

Change-type: major
Signed-off-by: Thomas Manning <thomasm@balena.io>